### PR TITLE
Switch Address Book to using $_GET instead of a query var.

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -95,19 +95,22 @@
 						dataType: 'json',
 						success : function( response ) {
 
-							$('#shipping_address_1').val(response.shipping_address_1);
-							$('#shipping_address_2').val(response.shipping_address_2);
-							$('#shipping_city').val(response.shipping_city);
-							$('#shipping_company').val(response.shipping_company);
+							// Loop through all fields incase there are custom ones.
+							Object.keys(response).forEach( function(key) {
+								$('#shipping_address_1').val(response.shipping_address_1);
+								$('#' + key).val(response[key]);
+							});
+
+							// Set Country Dropdown.
 							$('#shipping_country').val(response.shipping_country).change();
 							$("#shipping_country_chosen").find('span').html(response.shipping_country_text);
-							$('#shipping_first_name').val(response.shipping_first_name);
-							$('#shipping_last_name').val(response.shipping_last_name);
-							$('#shipping_postcode').val(response.shipping_postcode);
+
+							// Set state dropdown.
 							$('#shipping_state').val(response.shipping_state);
 							var stateName = $('#shipping_state option[value="'+response.shipping_state+'"]').text();
 							$("#s2id_shipping_state").find('.select2-chosen').html(stateName).parent().removeClass('select2-default');
 
+							// Remove loading screen.
 							$( '.shipping_address' ).removeClass('blockUI blockOverlay wc-updating');
 
 						}

--- a/templates/myaccount/my-address-book.php
+++ b/templates/myaccount/my-address-book.php
@@ -63,7 +63,7 @@ if ( ! $type ) : ?>
 
 					<div class="wc-address-book-address">
 						<div class="wc-address-book-meta">
-							<a href="<?php echo wc_get_endpoint_url( 'edit-address', $name . '/' ); ?>" class="wc-address-book-edit"><?php _e( 'Edit', 'woocommerce' ); ?></a>
+							<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?ab=' . $name ); ?>" class="wc-address-book-edit"><?php _e( 'Edit', 'woocommerce' ); ?></a>
 							<a id="<?php echo $name ?>" class="wc-address-book-delete"><?php _e( 'Delete', 'woocommerce' ); ?></a>
 							<a id="<?php echo $name ?>" class="wc-address-book-make-primary"><?php _e( 'Make Primary', 'woocommerce' ); ?></a>
 						</div>

--- a/templates/myaccount/my-address-book.php
+++ b/templates/myaccount/my-address-book.php
@@ -63,7 +63,7 @@ if ( ! $type ) : ?>
 
 					<div class="wc-address-book-address">
 						<div class="wc-address-book-meta">
-							<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?ab=' . $name ); ?>" class="wc-address-book-edit"><?php _e( 'Edit', 'woocommerce' ); ?></a>
+							<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?address-book=' . $name ); ?>" class="wc-address-book-edit"><?php _e( 'Edit', 'woocommerce' ); ?></a>
 							<a id="<?php echo $name ?>" class="wc-address-book-delete"><?php _e( 'Delete', 'woocommerce' ); ?></a>
 							<a id="<?php echo $name ?>" class="wc-address-book-make-primary"><?php _e( 'Make Primary', 'woocommerce' ); ?></a>
 						</div>

--- a/templates/myaccount/my-address-book.php
+++ b/templates/myaccount/my-address-book.php
@@ -4,7 +4,7 @@
  *
  * @author 	Hall Internet Marketing
  * @package	WooCommerce Address Book/Templates
- * @version	1.0.0
+ * @version	1.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: WooCommerce Address Book
  * Description: Gives your customers the option to store multiple shipping addresses and retrieve them on checkout..
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Hall Internet Marketing
  * Author URI: https://hallme.com
  * License: GPL2


### PR DESCRIPTION
Switching to the $_GET var allows for actions called on `woocommerce_shipping_fields` to effect all address book addresses.

Updated AJAX and JS to also check for custom fields and update their values on checkout if needed.

NOTE: This currently creates a PHP notice on address saving which errors out if wp_debug is turned on. Still looking into a fix for this.