### PR TITLE
Refactor address save

### DIFF
--- a/templates/myaccount/my-address-book.php
+++ b/templates/myaccount/my-address-book.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-$WC_Address_Book = new WC_Address_Book; 
+$WC_Address_Book = new WC_Address_Book;
 
 $customer_id = get_current_user_id();
 $address_book = $WC_Address_Book->get_address_book( $customer_id );
@@ -22,7 +22,7 @@ if ( ! $type ) : ?>
 	<?php
 
 	$shipping_address = get_user_meta( $customer_id, 'shipping_address_1', true );
-	
+
 	// Only display if primary addresses are set and not on an edit page.
 	if ( ! empty( $shipping_address ) ) : ?>
 
@@ -63,7 +63,7 @@ if ( ! $type ) : ?>
 
 					<div class="wc-address-book-address">
 						<div class="wc-address-book-meta">
-							<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?address-book=' . $name ); ?>" class="wc-address-book-edit"><?php _e( 'Edit', 'woocommerce' ); ?></a>
+							<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?address-book=' . $name . '&edit-address=' . $name ); ?>" class="wc-address-book-edit"><?php _e( 'Edit', 'woocommerce' ); ?></a>
 							<a id="<?php echo $name ?>" class="wc-address-book-delete"><?php _e( 'Delete', 'woocommerce' ); ?></a>
 							<a id="<?php echo $name ?>" class="wc-address-book-make-primary"><?php _e( 'Make Primary', 'woocommerce' ); ?></a>
 						</div>

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -127,13 +127,13 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				if ( empty( $address_book ) ) {
 
 					$shipping_address = get_user_meta( $user->ID, 'shipping_address_1', true );
-					
+
 					if ( ! empty( $shipping_address ) ) {
 						$this->save_address_names( $user->ID, array( 'shipping' ) );
 					}
 				}
 			}
-		
+
 			flush_rewrite_rules();
 		}
 
@@ -222,6 +222,9 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			if ( isset( $address_names ) && ! empty( $address_names ) ) {
 
 				$new = str_replace('shipping', '', end( $address_names ));
+				if ( empty( $new ) ) {
+					$new = 0;
+				}
 				$name = 'shipping' . intval ( $new  + 1, 10 );
 
 			} else { // Start the address book.
@@ -488,7 +491,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 						$field = str_replace( 'shipping', '', $field );
 
 						$address[$name . $field] = get_user_meta( $user_id, $name . $field, true );
-				
+
 					}
 
 					$address_book[$name] = $address;

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -93,8 +93,6 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			// Standardize the address edit fields to match Woo's IDs.
 			add_action( 'woocommerce_form_field_args', array( $this, 'standardize_field_ids' ), 20, 3 );
 
-			add_action( 'woocommerce_shipping_fields', array( $this, 'replace_address_key' ), 1001, 2 );
-
 		} // end constructor
 
 		/**
@@ -204,7 +202,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			?>
 
 			<div class="add-new-address">
-				<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?address-book=' . $name ); ?>" class="add button"><?php _e( 'Add New Shipping Address', 'wc-address-book' ); ?></a>
+				<a href="<?php echo wc_get_endpoint_url( 'edit-address', 'shipping/?address-book=' . $name . '&edit-address=' . $name ); ?>" class="add button"><?php _e( 'Add New Shipping Address', 'wc-address-book' ); ?></a>
 			</div>
 
 			<?php
@@ -769,29 +767,6 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			}
 
 			return $args;
-		}
-
-		/**
-		 * Replace the standard 'Shipping' address key with address book key.
-		 *
-		 * @param Array $address_fields - The set of WooCommerce Address Fields.
-		 *
-		 * @since 1.1.0
-		 */
-		function replace_address_key( $address_fields ) {
-
-			if ( isset( $_GET['address-book'] ) ) {
-
-				foreach ( $address_fields as $key => $value ) {
-
-					$newkey = str_replace( 'shipping', esc_attr( $_GET['address-book'] ), $key );
-
-					$address_fields[$newkey] = $address_fields[$key];
-					unset( $address_fields[$key] );
-				}
-			}
-
-			return $address_fields;
 		}
 
 	} // end class

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -483,7 +483,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 						continue;
 					}
 
-					unset($address);
+					$address = array();
 
 					foreach ( $address_fields as $field ) {
 


### PR DESCRIPTION
This changes how WooCommerece sees the `edit-address` variable so `save_address` can save it when editing the addresses. This it a different approch to my fix in #5 and is a replacement for that.

In addition:

- fix PHP warning when on first address with no number
- instead of unsetting $address initialize it as a new array

Fixes #4