### PR TITLE
Change scoping selector for AJAX calls

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -16,7 +16,7 @@
 		/*
 		 * AJAX call to delete address books.
 		 */
-		$('.address-book .wc-address-book-delete').click( function( e ) {
+		$('.address_book .wc-address-book-delete').click( function( e ) {
 
 			e.preventDefault();
 
@@ -40,7 +40,7 @@
 		/*
 		 * AJAX call to switch address to primary.
 		 */
-		$('.address-book .wc-address-book-make-primary').click( function( e ) {
+		$('.address_book .wc-address-book-make-primary').click( function( e ) {
 
 			e.preventDefault();
 


### PR DESCRIPTION
When shipping is disabled in WooCommerce the `.address-book` selector won't be present on the MyAccount page. Instead the `.address_book` selector should be used (note the underscore) which wraps the entry address book.