### PR TITLE
limit get_users to just returning IDs

### DIFF
--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -133,17 +133,17 @@ if ( ! is_plugin_active( $woo_path ) && ! is_plugin_active_for_network( $woo_pat
 			}
 
 			// Write a user's shipping address to the user_meta if they do not already have an address book saved.
-			$users = get_users();
-			foreach ( $users as $user ) {
+			$users = get_users( array ('fields' => 'ID') );
+			foreach ( $users as $user_id ) {
 
-				$address_book = $this->get_address_names( $user->ID );
+				$address_book = $this->get_address_names( $user_id );
 
 				if ( empty( $address_book ) ) {
 
-					$shipping_address = get_user_meta( $user->ID, 'shipping_address_1', true );
+					$shipping_address = get_user_meta( $user_id, 'shipping_address_1', true );
 
 					if ( ! empty( $shipping_address ) ) {
-						$this->save_address_names( $user->ID, array( 'shipping' ) );
+						$this->save_address_names( $user_id, array( 'shipping' ) );
 					}
 				}
 			}


### PR DESCRIPTION
significantly decreases the amount of memory needed on activation on a site with many users.

background here: https://wordpress.org/support/topic/fatal-error-could-not-be-activated/