### PR TITLE
Fix save address for WooCommerce 3.6.x

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,9 @@ No, this plugin only allows for the storage of multiple shipping addresses. If a
 
 == Changelog ==
 
+= 1.5.0 =
+* Fix address saving for new addresses in the address book for WooCommerce 3.6.x due to a change in the save address process
+
 = 1.4.1 =
 * Limit get_users to just returning IDs. Significantly decreases the amount of memory needed on activation on a site with many users. ([thanks pjv](https://github.com/hallme/woo-address-book/pull/40))
 * PHP and JS formatting cleanup

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -106,7 +106,7 @@ if ( ! is_plugin_active( $woo_path ) && ! is_plugin_active_for_network( $woo_pat
 			// Standardize the address edit fields to match Woo's IDs.
 			add_action( 'woocommerce_form_field_args', array( $this, 'standardize_field_ids' ), 20, 3 );
 
-			add_action( 'woocommerce_shipping_fields', array( $this, 'replace_address_key' ), 1001, 2 );
+			add_filter( 'woocommerce_shipping_fields', array( $this, 'replace_address_key' ), 1001, 2 );
 
 		} // end constructor
 


### PR DESCRIPTION
An additional check to check `$_POST[ 'shipping_country' ]` was added before we rewrite the fields which was causing the address to not save.

Implemented a workaround to satisfy that check.

Fixes #43

WooCommerce change that introduced the check:
https://github.com/woocommerce/woocommerce/commit/5b3b285a9d6c2e409bc16116d51c1df369aa1747#diff-03ffb149fa7b574bf8b56aa7d85b6aec