### PR TITLE
Conditionally load the plugin styles and scripts

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -4,188 +4,183 @@
  * @package woo-address-book
  */
 
-(function (window, $, undefined) {
+(function($){
 
-	$( document ).ready(
-		function () {
+	 // SelectWoo / Select2 Enhancement if it exists.
+	 if ($.fn.selectWoo) {
+		 $( 'select#shipping_address:visible, select#address_book:visible' ).each(
+			 function () {
+				 $( this ).selectWoo();
+			 }
+		 );
+	 } else if ($.fn.select2) {
+		 $( 'select#shipping_address:visible, select#address_book:visible' ).each(
+			 function () {
+				 $( this ).select2();
+			 }
+		 );
+	 }
 
-			// SelectWoo / Select2 Enhancement if it exists.
-			if ($.fn.selectWoo) {
-				$( 'select#shipping_address:visible, select#address_book:visible' ).each(
-					function () {
-						$( this ).selectWoo();
-					}
-				);
-			} else if ($.fn.select2) {
-				$( 'select#shipping_address:visible, select#address_book:visible' ).each(
-					function () {
-						$( this ).select2();
-					}
-				);
-			}
+	 /*
+	 * AJAX call to delete address books.
+	 */
+	 $( '.address_book .wc-address-book-delete' ).click(
+		 function (e) {
 
-			/*
-			* AJAX call to delete address books.
-			*/
-			$( '.address_book .wc-address-book-delete' ).click(
-				function (e) {
+			 e.preventDefault();
 
-					e.preventDefault();
+			 $( this ).closest( '.wc-address-book-address' ).addClass( 'blockUI blockOverlay wc-updating' );
 
-					$( this ).closest( '.wc-address-book-address' ).addClass( 'blockUI blockOverlay wc-updating' );
+			 var name = $( this ).attr( 'id' );
 
-					var name = $( this ).attr( 'id' );
+			 $.ajax(
+				 {
+					 url: woo_address_book.ajax_url,
+					 type: 'post',
+					 data: {
+						 action: 'wc_address_book_delete',
+						 name: name
+					 },
+					 success: function (response) {
+						 $( '.wc-updating' ).remove();
+					 }
+				 }
+			 );
+		 }
+	 );
 
-					$.ajax(
-						{
-							url: woo_address_book.ajax_url,
-							type: 'post',
-							data: {
-								action: 'wc_address_book_delete',
-								name: name
-							},
-							success: function (response) {
-								$( '.wc-updating' ).remove();
-							}
-						}
-					);
-				}
-			);
+	 /*
+	 * AJAX call to switch address to primary.
+	 */
+	 $( '.address_book .wc-address-book-make-primary' ).click(
+		 function (e) {
 
-			/*
-			* AJAX call to switch address to primary.
-			*/
-			$( '.address_book .wc-address-book-make-primary' ).click(
-				function (e) {
+			 e.preventDefault();
 
-					e.preventDefault();
+			 var name            = $( this ).attr( 'id' );
+			 var primary_address = $( '.woocommerce-Addresses .u-column2.woocommerce-Address address' );
+			 var alt_address     = $( this ).parent().siblings( 'address' );
 
-					var name            = $( this ).attr( 'id' );
-					var primary_address = $( '.woocommerce-Addresses .u-column2.woocommerce-Address address' );
-					var alt_address     = $( this ).parent().siblings( 'address' );
+			 // Swap HTML values for address and label.
+			 var pa_html = primary_address.html();
+			 var aa_html = alt_address.html();
 
-					// Swap HTML values for address and label.
-					var pa_html = primary_address.html();
-					var aa_html = alt_address.html();
+			 alt_address.html( pa_html );
+			 primary_address.html( aa_html );
 
-					alt_address.html( pa_html );
-					primary_address.html( aa_html );
+			 primary_address.addClass( 'blockUI blockOverlay wc-updating' );
+			 alt_address.addClass( 'blockUI blockOverlay wc-updating' );
 
-					primary_address.addClass( 'blockUI blockOverlay wc-updating' );
-					alt_address.addClass( 'blockUI blockOverlay wc-updating' );
+			 $.ajax(
+				 {
+					 url: woo_address_book.ajax_url,
+					 type: 'post',
+					 data: {
+						 action: 'wc_address_book_make_primary',
+						 name: name
+					 },
+					 success: function (response) {
+						 $( '.wc-updating' ).removeClass( 'blockUI blockOverlay wc-updating' );
+					 }
+				 }
+			 );
+		 }
+	 );
 
-					$.ajax(
-						{
-							url: woo_address_book.ajax_url,
-							type: 'post',
-							data: {
-								action: 'wc_address_book_make_primary',
-								name: name
-							},
-							success: function (response) {
-								$( '.wc-updating' ).removeClass( 'blockUI blockOverlay wc-updating' );
-							}
-						}
-					);
-				}
-			);
+	 /*
+	 * AJAX call display address on checkout when selected.
+	 */
+	 function shipping_checkout_field_prepop() {
 
-			/*
-			* AJAX call display address on checkout when selected.
-			*/
-			function shipping_checkout_field_prepop() {
+		 var that = $( '#address_book_field #address_book' );
+		 var name = $( that ).val();
 
-				var that = $( '#address_book_field #address_book' );
-				var name = $( that ).val();
+		 if (name !== undefined) {
 
-				if (name !== undefined) {
+			 if ('add_new' == name) {
 
-					if ('add_new' == name) {
+				 // Clear values when adding a new address.
+				 $( '.shipping_address input' ).not( $( '#shipping_country' ) ).each(
+					 function () {
+						 $( this ).val( '' );
+					 }
+				 );
 
-						// Clear values when adding a new address.
-						$( '.shipping_address input' ).not( $( '#shipping_country' ) ).each(
-							function () {
-								$( this ).val( '' );
-							}
-						);
+				 // Set Country Dropdown.
+				 // Don't reset the value if only one country is available to choose.
+				 var country_input = $( '#shipping_country' );
+				 if (country_input.length > 0 && country_input.attr("readonly") !== "readonly") {
+					 country_input.val( '' ).change();
+					 $( "#shipping_country_chosen" ).find( 'span' ).html( '' );
+				 }
 
-						// Set Country Dropdown.
-						// Don't reset the value if only one country is available to choose.
-						var country_input = $( '#shipping_country' );
-						if (country_input.length > 0 && country_input.attr("readonly") !== "readonly") {
-							country_input.val( '' ).change();
-							$( "#shipping_country_chosen" ).find( 'span' ).html( '' );
-						}
+				 // Set state dropdown.
+				 var state_input = $( '#shipping_state' );
+				 if (state_input.length > 0 && state_input.attr("readonly") !== "readonly") {
+					 state_input.val( '' ).change();
+					 $( "#shipping_state_chosen" ).find( 'span' ).html( '' );
+				 }
 
-						// Set state dropdown.
-						var state_input = $( '#shipping_state' );
-						if (state_input.length > 0 && state_input.attr("readonly") !== "readonly") {
-							state_input.val( '' ).change();
-							$( "#shipping_state_chosen" ).find( 'span' ).html( '' );
-						}
+				 return;
+			 }
 
-						return;
-					}
+			 if (name.length > 0) {
 
-					if (name.length > 0) {
+				 $( that ).closest( '.shipping_address' ).addClass( 'blockUI blockOverlay wc-updating' );
 
-						$( that ).closest( '.shipping_address' ).addClass( 'blockUI blockOverlay wc-updating' );
+				 $.ajax(
+					 {
+						 url: woo_address_book.ajax_url,
+						 type: 'post',
+						 data: {
+							 action: 'wc_address_book_checkout_update',
+							 name: name
+						 },
+						 dataType: 'json',
+						 success: function (response) {
 
-						$.ajax(
-							{
-								url: woo_address_book.ajax_url,
-								type: 'post',
-								data: {
-									action: 'wc_address_book_checkout_update',
-									name: name
-								},
-								dataType: 'json',
-								success: function (response) {
+							 // Loop through all fields incase there are custom ones.
+							 Object.keys( response ).forEach(
+								 function (key) {
+									 var input = $( '#' + key );
+									 if (input.length > 0 && input.attr("readonly") !== "readonly") {
+										 input.val( response[key] ).change();
+									 }
+								 }
+							 );
 
-									// Loop through all fields incase there are custom ones.
-									Object.keys( response ).forEach(
-										function (key) {
-											var input = $( '#' + key );
-											if (input.length > 0 && input.attr("readonly") !== "readonly") {
-												input.val( response[key] ).change();
-											}
-										}
-									);
+							 // Set Country Dropdown.
+							 var country_input = $( '#shipping_country' );
+							 if (country_input.length > 0 && country_input.attr("readonly") !== "readonly") {
+								 country_input.val( response.shipping_country ).change();
+								 $( "#shipping_country_chosen" ).find( 'span' ).html( response.shipping_country_text );
+							 }
 
-									// Set Country Dropdown.
-									var country_input = $( '#shipping_country' );
-									if (country_input.length > 0 && country_input.attr("readonly") !== "readonly") {
-										country_input.val( response.shipping_country ).change();
-										$( "#shipping_country_chosen" ).find( 'span' ).html( response.shipping_country_text );
-									}
+							 // Set state dropdown.
+							 var state_input = $( '#shipping_state' );
+							 if (state_input.length > 0 && state_input.attr("readonly") !== "readonly") {
+								 state_input.val( response.shipping_state );
+								 var stateName = $( '#shipping_state option[value="' + response.shipping_state + '"]' ).text();
+								 $( "#s2id_shipping_state" ).find( '.select2-chosen' ).html( stateName ).parent().removeClass( 'select2-default' );
+							 }
 
-									// Set state dropdown.
-									var state_input = $( '#shipping_state' );
-									if (state_input.length > 0 && state_input.attr("readonly") !== "readonly") {
-										state_input.val( response.shipping_state );
-										var stateName = $( '#shipping_state option[value="' + response.shipping_state + '"]' ).text();
-										$( "#s2id_shipping_state" ).find( '.select2-chosen' ).html( stateName ).parent().removeClass( 'select2-default' );
-									}
+							 // Remove loading screen.
+							 $( '.shipping_address' ).removeClass( 'blockUI blockOverlay wc-updating' );
 
-									// Remove loading screen.
-									$( '.shipping_address' ).removeClass( 'blockUI blockOverlay wc-updating' );
+						 }
+					 }
+				 );
 
-								}
-							}
-						);
+			 }
+		 }
+	 }
 
-					}
-				}
-			}
+	 shipping_checkout_field_prepop();
 
-			shipping_checkout_field_prepop();
+	 $( '#address_book_field #address_book' ).change(
+		 function () {
+			 shipping_checkout_field_prepop();
+		 }
+	 );
 
-			$( '#address_book_field #address_book' ).change(
-				function () {
-					shipping_checkout_field_prepop();
-				}
-			);
-		}
-	);
-
-})( window, jQuery );
+})(jQuery);

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -158,23 +158,25 @@ if ( ! is_plugin_active( $woo_path ) && ! is_plugin_active_for_network( $woo_pat
 		 *
 		 * @since 1.0.0
 		 */
-		public function scripts_styles() {
-			if ( ! is_admin() ) {
-				wp_enqueue_script( 'jquery' );
+		 public function scripts_styles() {
 
-				$min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-				wp_enqueue_style( 'woo-address-book', plugins_url( '/assets/css/style.css', __FILE__ ), array(), $this->version );
-				wp_enqueue_script( 'woo-address-book', plugins_url( "/assets/js/scripts$min.js", __FILE__ ), array( 'jquery' ), $this->version, true );
+			 $min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+			 wp_register_style( 'woo-address-book', plugins_url( '/assets/css/style.css', __FILE__ ), array(), $this->version );
+			 wp_register_script( 'woo-address-book', plugins_url( "/assets/js/scripts$min.js", __FILE__ ), array( 'jquery' ), $this->version, true );
 
-				wp_localize_script(
-					'woo-address-book',
-					'woo_address_book',
-					array(
-						'ajax_url' => admin_url( 'admin-ajax.php' ),
-					)
-				);
-			}
-		}
+			 wp_localize_script(
+				 'woo-address-book',
+				 'woo_address_book',
+				 array(
+					 'ajax_url' => admin_url( 'admin-ajax.php' ),
+				 )
+			 );
+
+			 if( is_account_page() ) wp_enqueue_style( 'woo-address-book' );
+
+			 if( is_account_page() || is_checkout() ) wp_enqueue_script( 'woo-address-book' );
+
+		 }
 
 		/**
 		 * Adds a link/button to the my account page under the addresses for adding additional addresses to their account.


### PR DESCRIPTION
- Stop enqueuing the plugin styles and scripts on every page.
- Removes unnecessary "is_admin()" check and "wp_enqueue_script( 'jquery' )"
- Shorthand for "$( document ).ready"

☕️:bowtie: