### PR TITLE
Remove unneeded priority that cause select2 issues on the checkout page

### DIFF
--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -87,7 +87,7 @@ if ( ! is_plugin_active( $woo_path ) && ! is_plugin_active_for_network( $woo_pat
 			register_uninstall_hook( __FILE__, array( 'WC_Address_Book', 'uninstall' ) );
 
 			// Enqueue Styles and Scripts.
-			add_action( 'wp_enqueue_scripts', array( $this, 'scripts_styles' ), 20 );
+			add_action( 'wp_enqueue_scripts', array( $this, 'scripts_styles' ) );
 
 			// Save an address to the address book.
 			add_action( 'woocommerce_customer_save_address', array( $this, 'update_address_names' ), 10, 2 );


### PR DESCRIPTION
SelectWoo is not working on the addresses field when "Ship to a different address" option is unchecked by default. Remove the unneeded "wp_enqueue_scripts" priority solves the issue.

![selectwoo-bug](https://user-images.githubusercontent.com/11556124/64236331-7a450400-cefa-11e9-830a-518d79220aa3.gif)
