### PR TITLE
bump version tested up to to the latest versions the plugin is tested up to.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: hallme, doomwaxer, timbhowe, matt-h-1
 Tags: WooCommerce, address book, multiple addresses, address
 Requires at least: 4.6
-Tested up to: 5.4.1
+Tested up to: 5.5.2
 Stable tag: 1.7.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/woocommerce-address-book.php
+++ b/woocommerce-address-book.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: woo-address-book
- * WC tested up to: 4.1.0
+ * WC tested up to: 4.6.1
  *
  * @package WooCommerce Address Book
  */


### PR DESCRIPTION
- WooCommerce 4.6.1
- WordPress 5.5.2