### PR TITLE
Add settings to be able to configure address nickname during checkout.

### DIFF
--- a/includes/class-wc-address-book.php
+++ b/includes/class-wc-address-book.php
@@ -1220,17 +1220,17 @@ class WC_Address_Book {
 	}
 
 	/**
-	 * Don't show Address Nickname field on the checkout. This is only for Edit/Add address.
+	 * Don't show Address Nickname field on the checkout if the option is configured not to.
 	 *
 	 * @param array $fields Checkout fields.
 	 * @return array
 	 */
 	public function remove_nickname_field_from_checkout( $fields ) {
-		if ( isset( $fields['shipping']['shipping_address_nickname'] ) ) {
+		if ( isset( $fields['shipping']['shipping_address_nickname'] ) && ! $this->get_wcab_option( 'shipping_address_nickname_checkout', 'no' ) ) {
 			unset( $fields['shipping']['shipping_address_nickname'] );
 		}
 
-		if ( isset( $fields['billing']['billing_address_nickname'] ) ) {
+		if ( isset( $fields['billing']['billing_address_nickname'] ) && ! $this->get_wcab_option( 'shipping_address_nickname_checkout', 'no' ) ) {
 			unset( $fields['billing']['billing_address_nickname'] );
 		}
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -38,6 +38,13 @@ function woo_address_book_general_settings( $settings ) {
 	);
 
 	$settings[] = array(
+		'desc'    => __( 'Enable setting Billing Address Nickname during Checkout', 'woo-address-book' ),
+		'id'      => 'woo_address_book_billing_address_nickname_checkout',
+		'default' => 'no',
+		'type'    => 'checkbox',
+	);
+
+	$settings[] = array(
 		'title'   => __( 'Shipping address book', 'woo-address-book' ),
 		'desc'    => __( 'Enable shipping address book', 'woo-address-book' ),
 		'id'      => 'woo_address_book_shipping_enable',
@@ -48,6 +55,13 @@ function woo_address_book_general_settings( $settings ) {
 	$settings[] = array(
 		'desc'    => __( 'Add New Address as default selection', 'woo-address-book' ),
 		'id'      => 'woo_address_book_shipping_default_to_new_address',
+		'default' => 'no',
+		'type'    => 'checkbox',
+	);
+
+	$settings[] = array(
+		'desc'    => __( 'Enable setting Shipping Address Nickname during Checkout', 'woo-address-book' ),
+		'id'      => 'woo_address_book_shipping_address_nickname_checkout',
 		'default' => 'no',
 		'type'    => 'checkbox',
 	);


### PR DESCRIPTION
Adds new options to the WooCommerce settings to enable Address Nickname during checkout. These are off by default.

Closes #94