### PR TITLE
Fix saving address if billing or shipping address book on checkout is disabled.

### DIFF
--- a/includes/class-wc-address-book.php
+++ b/includes/class-wc-address-book.php
@@ -854,16 +854,25 @@ class WC_Address_Book {
 		}
 
 		// Name new address and update address book.
-		if ( 'add_new' === $billing_name || false === $billing_name ) {
-			$address_names = $this->get_address_names( $customer_id, 'billing' );
-			$billing_name  = $this->set_new_address_name( $address_names, 'billing' );
-			$this->add_address_name( $customer_id, $billing_name, 'billing' );
+		if ( $this->get_wcab_option( 'billing_enable' ) === true ) {
+			if ( 'add_new' === $billing_name || false === $billing_name ) {
+				$address_names = $this->get_address_names( $customer_id, 'billing' );
+				$billing_name  = $this->set_new_address_name( $address_names, 'billing' );
+				$this->add_address_name( $customer_id, $billing_name, 'billing' );
+			}
+		} else {
+			$billing_name = 'billing';
 		}
 
-		if ( ( 'add_new' === $shipping_name || false === $shipping_name ) && false === $ignore_shipping_address ) {
-			$address_names = $this->get_address_names( $customer_id, 'shipping' );
-			$shipping_name = $this->set_new_address_name( $address_names, 'shipping' );
-			$this->add_address_name( $customer_id, $shipping_name, 'shipping' );
+		if ( $this->get_wcab_option( 'shipping_enable' ) === true ) {
+			if ( ( 'add_new' === $shipping_name || false === $shipping_name ) && false === $ignore_shipping_address ) {
+				$address_names = $this->get_address_names( $customer_id, 'shipping' );
+				$shipping_name = $this->set_new_address_name( $address_names, 'shipping' );
+				$this->add_address_name( $customer_id, $shipping_name, 'shipping' );
+			}
+		}
+		else {
+			$shipping_name = 'shipping';
 		}
 
 		$data = $checkout_object->get_posted_data();

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,9 @@ You may also use PoEdit and create a translation file which can be exported as a
 
 == Changelog ==
 
+= 2.1.3 =
+* Fix: Address saving to customer Address Book if Billing or Shipping Address Book was disabled. [#128](https://github.com/hallme/woo-address-book/issues/128)
+
 = 2.1.2 =
 * Fix: "Enable setting Billing Address Nickname during Checkout" setting not working properly [#121](https://github.com/hallme/woo-address-book/issues/121)
 


### PR DESCRIPTION
It had saved to the order fine but saving to customer profile was
treating it as if "Add New" was selected if the address book was
disabled.

Fixes https://github.com/hallme/woo-address-book/issues/128